### PR TITLE
Redirect readthedocs to new documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ htmlcov/
 .coverage
 .ipynb_checkpoints/
 docs/examples/*.h5
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,2 @@
+PTSA documentation has [moved](https://pennmem.github.io/ptsa/). You should be
+redirected automatically.

--- a/docs/redirect/main.html
+++ b/docs/redirect/main.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <title>PTSA documentation has moved</title>
+  </head>
+  <body>
+    {{ content }}
+    <script>
+      window.onload = function () {
+        window.location = "https://pennmem.github.io/ptsa/";
+      };
+    </script>
+  </body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+# Dummy mkdocs.yml file so that we can redirect from readthedocs to the new PTSA
+# documentation home on Github.
+site_name: PTSA docs have moved
+pages:
+  - Home: index.md
+theme_dir: docs/redirect

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,0 @@
-conda:
-    file: environment.yml
-
-# Don't build any extra formats
-formats:
-    - none
-
-python:
-   setup_py_install: true


### PR DESCRIPTION
This uses a minimal mkdocs configuration to load a page which uses Javascript to immediately redirect to the new documentation location.