### PR TITLE
Update __init__.py

### DIFF
--- a/ptsa/data/MatlabIO/__init__.py
+++ b/ptsa/data/MatlabIO/__init__.py
@@ -51,10 +51,10 @@ def read_single_matlab_matrix_as_numpy_structured_array(file_name, object_name, 
     except KeyError:
         return None
 
-    # picking first first elment  plus 20 randomly selected elements to determine type
-    selector_array = [0] + np.random.randint(len(matlab_matrix_as_python_obj), size=20)
-    selector_array = np.hstack(([0], selector_array))
-    template_element_array = matlab_matrix_as_python_obj[selector_array]
+    # # picking first first elment  plus 20 randomly selected elements to determine type
+    # selector_array = [0] + np.random.randint(len(matlab_matrix_as_python_obj), size=20)
+    # selector_array = np.hstack(([0], selector_array))
+    template_element_array = matlab_matrix_as_python_obj  # [selector_array]
 
     record = matlab_matrix_as_python_obj[0]
     # format_dict = get_np_format([record])


### PR DESCRIPTION
The use of only 20 elements to determine the dtype is creating problems and in some cases might lead to undetected data corruption. As a temporary measure I've changed the code to consider all elements rather than just 20 random elements. For efficiency we could consider an alternative method (we discussed heuristics based on the sum previously), but it'd be good to additionally (or instead) give users the option to specify dtypes when loading in the data (a possible use is if different data sets are read in separately and are to be combined later -- even when all elements in a given data set are considered for the determination of dtype, a missmatch between data sets can still occur).