### PR TITLE
Allow for reading stimOnly matlab talstructs

### DIFF
--- a/ptsa/data/readers/TalReader.py
+++ b/ptsa/data/readers/TalReader.py
@@ -93,8 +93,7 @@ class TalReader(PropertiedObject,BaseReader):
         if not self._json:
             from ptsa.data.MatlabIO import read_single_matlab_matrix_as_numpy_structured_array
 
-            struct_names = ['bpTalStruct','subjTalEvents']
-            # struct_names = ['bpTalStruct']
+            struct_names = ['bpTalStruct','subjTalEvents', 'virtualTalStruct']
             if self.struct_name not in struct_names:
                 self.tal_struct_array = read_single_matlab_matrix_as_numpy_structured_array(self.filename, self.struct_name,verbose=False)
                 if self.tal_struct_array is not None:
@@ -103,7 +102,6 @@ class TalReader(PropertiedObject,BaseReader):
                     raise AttributeError('Could not read tal struct data for the specified struct_name='+self.struct_name)
 
             else:
-
                 for sn in struct_names:
                     self.tal_struct_array = read_single_matlab_matrix_as_numpy_structured_array(self.filename,sn,verbose=False)
                     if self.tal_struct_array is not None:


### PR DESCRIPTION
Some subjects have an additional matlab talstruct database [SUBJECT_ID]_talLocs_database_stimOnly.mat containing a 'virtualTalStruct' for any contacts that are not part of the original set of bipolar pairs, but were chosen for stimulation. This currently cannot be read by the talReader because it does not recognize that struct name. Simply added the new struct name as an option and tested that it works for a few subjects with this file (R1028M, R1041M).