### PR TITLE
Replace PyTables with h5py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
 - pandas
 - pip
 - pyparsing
-- pytables
 - python
 - python-dateutil
 - pytz

--- a/ptsa/data/readers/H5RawReader.py
+++ b/ptsa/data/readers/H5RawReader.py
@@ -8,7 +8,7 @@ class H5RawReader(BaseRawReader):
     """Class for reading raw EEG data stored in HDF5 format."""
     def __init__(self, **kwargs):
         """
-        :param kwds:allowed values are:
+        :param kwargs: allowed values are:
         -------------------------------------
         :param dataroot {str} -  Full name of hdf5 file. Normally this is the eegfile field from events record
 
@@ -38,20 +38,22 @@ class H5RawReader(BaseRawReader):
         """
         with h5py.File(self.dataroot, 'r') as eegfile:
             if len(channels) == 0:
-                channels = self.channels = np.array(['{:03d}'.format(x) for x in eegfile.root.ports[:]])
+                channels = self.channels = np.array(['{:03d}'.format(x).encode() for x in eegfile['/ports'][:]])
 
             try:
                 monopolar_possible = bool(eegfile['/monopolar_possible'][0])
 
                 if 'bipolar_info' in eegfile and not monopolar_possible:
                     if not (np.in1d(channels, eegfile['/bipolar_info/ch0_label']).all()):
-                        raise IndexError('Channel[s] %s not in recording'%(
-                            channels[~np.in1d(channels, eegfile['/bipolar_info/ch0_label'])])
-                                         )
+                        raise IndexError('Channel[s] %s not in recording' % (
+                            channels[~np.in1d(channels, eegfile['/bipolar_info/ch0_label'])]))
                     channel_mask = np.in1d(eegfile['/bipolar_info/ch0_label'], channels)
-                    self.channels = np.array(zip(eegfile['/bipolar_info/ch0_label'][channel_mask],
-                                              eegfile['/bipolar_info/ch1_label'][channel_mask]),
-                                            dtype=[('ch0', int), ('ch1', int)]).view(np.recarray)
+                    self.channels = np.array(
+                        list(
+                            zip(eegfile['/bipolar_info/ch0_label'][channel_mask],
+                                eegfile['/bipolar_info/ch1_label'][channel_mask]),
+                        ),
+                        dtype=[('ch0', int), ('ch1', int)]).view(np.recarray)
 
                     self.channel_name = 'bipolar_pairs'
             except KeyError:
@@ -60,9 +62,9 @@ class H5RawReader(BaseRawReader):
             channels_ = channels if self.channel_name == 'channels' else self.channels.ch0
             event_data, read_ok_mask = self.read_h5file(eegfile, channels_,
                                                         start_offsets, read_size)
-            if self.read_size==-1:
+            if self.read_size == -1:
                 self.read_size = max(event_data.shape)
-            return event_data,read_ok_mask
+            return event_data, read_ok_mask
 
     @staticmethod
     def read_h5file(eegfile, channels, start_offsets=np.array([0]), read_size=-1):

--- a/ptsa/data/readers/H5RawReader.py
+++ b/ptsa/data/readers/H5RawReader.py
@@ -20,7 +20,7 @@ class H5RawReader(BaseRawReader):
         --------------------------------------
         :return:None
         """
-        _,data_ext = osp.splitext(kwargs['dataroot'])
+        _, data_ext = osp.splitext(kwargs['dataroot'])
         assert len(data_ext), 'Dataroot missing extension'
         super(H5RawReader, self).__init__(**kwargs)
 

--- a/ptsa/data/readers/H5RawReader.py
+++ b/ptsa/data/readers/H5RawReader.py
@@ -1,16 +1,13 @@
 from .BaseRawReader import BaseRawReader
 import numpy as np
-import tables
+import h5py
 import os.path as osp
 
-class H5RawReader(BaseRawReader):
-    """
-    Class for reading raw EEG data stored in HDF5 format.
-    """
 
-    def __init__(self,**kwargs):
+class H5RawReader(BaseRawReader):
+    """Class for reading raw EEG data stored in HDF5 format."""
+    def __init__(self, **kwargs):
         """
-        Constructor
         :param kwds:allowed values are:
         -------------------------------------
         :param dataroot {str} -  Full name of hdf5 file. Normally this is the eegfile field from events record
@@ -23,15 +20,11 @@ class H5RawReader(BaseRawReader):
         --------------------------------------
         :return:None
         """
-
-
         _,data_ext = osp.splitext(kwargs['dataroot'])
         assert len(data_ext), 'Dataroot missing extension'
         super(H5RawReader, self).__init__(**kwargs)
 
-
-
-    def read_file(self,filename, channels, start_offsets=np.array([0]), read_size=-1):
+    def read_file(self, filename, channels, start_offsets=np.array([0]), read_size=-1):
         """
         Overloads BaseRawReader.read_file(). Does some mangling of the channels parameter if it is empty or if the
         HDF5 file is a bipolar recording
@@ -43,18 +36,18 @@ class H5RawReader(BaseRawReader):
         :return: event_data: The EEG data corresponding to each offset
         :return: read_ok_mask: Boolean mask indicating whether each offset was read successfully.
         """
-        with tables.open_file(self.dataroot) as eegfile:
+        with h5py.File(self.dataroot, 'r') as eegfile:
             if len(channels)==0:
                 channels = self.channels = np.array(['{:03d}'.format(x) for x in eegfile.root.ports[:]])
-            if 'bipolar_info' in eegfile.root and ('monopolar_possible' in eegfile.root and eegfile.root.monopolar_possible[:]==False):
-                if not (np.in1d(channels,eegfile.root.bipolar_info.ch0_label).all()):
+            if 'bipolar_info' in eegfile and ('monopolar_possible' in eegfile and not eegfile['/monopolar_possible'][0]):
+                if not (np.in1d(channels, eegfile['/bipolar_info/ch0_label']).all()):
                     raise IndexError('Channel[s] %s not in recording'%(
-                        channels[~np.in1d(channels,eegfile.root.bipolar_info.ch0_label)])
+                        channels[~np.in1d(channels, eegfile['/bipolar_info/ch0_label'])])
                                      )
-                channel_mask = np.in1d(eegfile.root.bipolar_info.ch0_label, channels)
-                self.channels = np.array(zip(eegfile.root.bipolar_info.ch0_label[channel_mask],
-                                          eegfile.root.bipolar_info.ch1_label[channel_mask]),
-                                        dtype=[('ch0',int),('ch1',int)]).view(np.recarray)
+                channel_mask = np.in1d(eegfile['/bipolar_info/ch0_label'], channels)
+                self.channels = np.array(zip(eegfile['/bipolar_info/ch0_label'][channel_mask],
+                                          eegfile['/bipolar_info/ch1_label'][channel_mask]),
+                                        dtype=[('ch0', int), ('ch1', int)]).view(np.recarray)
 
                 self.channel_name = 'bipolar_pairs'
             event_data,read_ok_mask = self.read_h5file(eegfile, channels if self.channel_name=='channels' else self.channels.ch0
@@ -77,8 +70,8 @@ class H5RawReader(BaseRawReader):
         :return: read_ok_mask: Boolean mask indicating whether each offset was read successfully.
 
         """
-        timeseries = eegfile.root.timeseries
-        ports = eegfile.root.ports
+        timeseries = eegfile['/timeseries']
+        ports = eegfile['/ports']
         channels_to_read = np.where(np.in1d(ports, channels.astype(int)))[0]
         if read_size < 0:
             if 'orient' in timeseries.attrs and timeseries.attrs['orient'] == 'row':
@@ -110,4 +103,4 @@ class H5RawReader(BaseRawReader):
                         'End of read interval  is outside the bounds of file ' + eegfile.filename)
                     read_ok_mask[:, i] = False
 
-            return eventdata,read_ok_mask,
+            return eventdata, read_ok_mask

--- a/ptsa/data/readers/H5RawReader.py
+++ b/ptsa/data/readers/H5RawReader.py
@@ -1,4 +1,4 @@
-from .BaseRawReader import BaseRawReader
+from ptsa.data.readers.BaseRawReader import BaseRawReader
 import numpy as np
 import h5py
 import os.path as osp
@@ -94,7 +94,7 @@ class H5RawReader(BaseRawReader):
             read_ok_mask = np.ones((len(channels), len(start_offsets))).astype(bool)
             for i, start_offset in enumerate(start_offsets):
                 try:
-                    if 'orient' in timeseries.attrs and timeseries.attrs['orient'] == 'row':
+                    if 'orient' in timeseries.attrs.keys() and timeseries.attrs['orient'] == b'row':
                         data = timeseries[start_offset:start_offset + read_size, channels_to_read].T
                     else:
                         data = timeseries[channels_to_read, start_offset:start_offset + read_size]
@@ -111,4 +111,14 @@ class H5RawReader(BaseRawReader):
                         'End of read interval  is outside the bounds of file ' + eegfile.filename)
                     read_ok_mask[:, i] = False
 
+            if np.isnan(eventdata).all():
+                raise RuntimeError("All eventdata is nan!")
+
             return eventdata, read_ok_mask
+
+
+if __name__ == "__main__":
+    filename = osp.expanduser("~/mnt/rhino/data/eeg/R1275D/behavioral/FR1/session_0/host_pc/20170531_170954/eeg_timeseries.h5")
+    channels = np.array(['%.03d' % i for i in range(1, 10)])
+    with h5py.File(filename, 'r') as hfile:
+        reader = H5RawReader.read_h5file(hfile, channels, [0], 1000)

--- a/tests/test_h5reader.py
+++ b/tests/test_h5reader.py
@@ -45,7 +45,7 @@ class TestH5Reader(unittest.TestCase):
             timestamp='20171026_160648'
         )
 
-        self.raw_dataroot = osp.join(
+        self.monopolar_dataroot = osp.join(
             root, 'protocols', 'r1', 'subjects', 'R1275D', 'experiments', 'FR1',
             'sessions', '0', 'ephys', 'current_processed', 'noreref',
             'R1275D_FR1_0_31May17_2109'
@@ -58,7 +58,10 @@ class TestH5Reader(unittest.TestCase):
         with h5py.File(self.monopolar_file, 'r') as hfile:
             h5_data, _ = H5RawReader.read_h5file(hfile, channels, [0], 1000)
 
-        raw_timeseries,_ = BaseRawReader(dataroot=self.raw_dataroot,channels=channels,start_offsets=np.array([0]),read_size=1000).read()
+        raw_timeseries, _ = BaseRawReader(dataroot=self.monopolar_dataroot,
+                                          channels=channels,
+                                          start_offsets=np.array([0]),
+                                          read_size=1000).read()
         assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
 
     def test_h5reader_many_offsets(self):
@@ -66,14 +69,22 @@ class TestH5Reader(unittest.TestCase):
 
         with h5py.File(self.monopolar_file, 'r') as hfile:
             h5_data, _ = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
-        raw_timeseries, _ = BaseRawReader(dataroot=self.raw_dataroot, channels=self.channels, start_offsets=offsets, read_size=1000).read()
+
+        raw_timeseries, _ = BaseRawReader(dataroot=self.monopolar_dataroot,
+                                          channels=self.channels,
+                                          start_offsets=offsets,
+                                          read_size=1000).read()
         assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
 
     def test_h5reader_out_of_bounds(self):
         offsets = np.arange(1000000, 4000000, 1000000)
         with h5py.File(self.monopolar_file, 'r') as hfile:
             h5_data, h5_mask = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
-        raw_data,raw_mask = BaseRawReader(dataroot=self.raw_dataroot,channels=self.channels,start_offsets=offsets,read_size=1000).read()
+
+        raw_data,raw_mask = BaseRawReader(dataroot=self.monopolar_dataroot,
+                                          channels=self.channels,
+                                          start_offsets=offsets,
+                                          read_size=1000).read()
         assert(raw_mask == h5_mask).all()
         assert(h5_data[h5_mask] == raw_data.data[raw_mask]).all()
 
@@ -111,7 +122,7 @@ class TestH5Reader(unittest.TestCase):
         del h5_data
         h5dur = toc-tic
         tic=time.time()
-        raw_data,_ = BaseRawReader(dataroot=self.raw_dataroot,channels=channels).read()
+        raw_data,_ = BaseRawReader(dataroot=self.monopolar_dataroot, channels=channels).read()
         toc=time.time()
         del raw_data
         rawdur = toc-tic

--- a/tests/test_h5reader.py
+++ b/tests/test_h5reader.py
@@ -1,13 +1,14 @@
 from ptsa.test.utils import get_rhino_root,skip_without_rhino
 import os.path as osp
 import unittest,pytest
-import tables
+import h5py
 import numpy as np
 from ptsa.data.readers.H5RawReader import H5RawReader
 from ptsa.data.readers.BaseRawReader import BaseRawReader
 from ptsa.data.readers.CMLEventReader import CMLEventReader
 from ptsa.data.readers import EEGReader
 import time
+
 
 @skip_without_rhino
 class TestH5Reader(unittest.TestCase):
@@ -17,13 +18,13 @@ class TestH5Reader(unittest.TestCase):
         self.raw_dataroot = osp.join(root,'protocols','r1','subjects','R1275D','experiments','FR1','sessions','0',
                                 'ephys','current_processed','noreref','R1275D_FR1_0_31May17_2109')
         self.channels = np.array(['%.03d'%i for i in range(1,10)])
-        self.h5file = tables.open_file(self.h5_dataroot)
+        self.h5file = h5py.File(self.h5_dataroot, 'r')
 
     def tearDown(self):
         self.h5file.close()
 
     def test_h5reader_one_offset(self):
-        channels=self.channels
+        channels = self.channels
         h5_data,_ = H5RawReader.read_h5file(self.h5file, channels, [0], 1000)
 
         raw_timeseries,_ = BaseRawReader(dataroot=self.raw_dataroot,channels=channels,start_offsets=np.array([0]),read_size=1000).read()
@@ -61,8 +62,6 @@ class TestH5Reader(unittest.TestCase):
         events = CMLEventReader(filename=dataroot_format).read()[:20]
         eeg = EEGReader(events=events,channels=np.array([]),start_time=0.0,end_time=0.5).read()
         assert len(eeg.bipolar_pairs)>0
-
-
 
     @pytest.mark.skip
     @pytest.mark.slow

--- a/tests/test_h5reader.py
+++ b/tests/test_h5reader.py
@@ -1,51 +1,89 @@
-from ptsa.test.utils import get_rhino_root,skip_without_rhino
 import os.path as osp
-import unittest,pytest
+import time
+import unittest
+import pytest
+
 import h5py
 import numpy as np
+
 from ptsa.data.readers.H5RawReader import H5RawReader
 from ptsa.data.readers.BaseRawReader import BaseRawReader
 from ptsa.data.readers.CMLEventReader import CMLEventReader
 from ptsa.data.readers import EEGReader
-import time
+from ptsa.test.utils import get_rhino_root, skip_without_rhino
 
 
 @skip_without_rhino
 class TestH5Reader(unittest.TestCase):
     def setUp(self):
         root = get_rhino_root()
-        self.h5_dataroot = osp.join(root,'data','eeg','R1275D','behavioral','FR1','session_0','host_pc','20170531_170954','eeg_timeseries.h5')
-        self.raw_dataroot = osp.join(root,'protocols','r1','subjects','R1275D','experiments','FR1','sessions','0',
-                                'ephys','current_processed','noreref','R1275D_FR1_0_31May17_2109')
-        self.channels = np.array(['%.03d'%i for i in range(1,10)])
-        self.h5file = h5py.File(self.h5_dataroot, 'r')
+        self.eeg_path_template = osp.join(
+            root, 'data', 'eeg', '{subject:s}', 'behavioral', '{experiment:s}',
+            'session_{session:d}', 'host_pc', '{timestamp:s}',
+            'eeg_timeseries.h5'
+        )
 
-    def tearDown(self):
-        self.h5file.close()
+        self.dataroot_template = osp.join(
+            root, 'protocols', 'r1', 'subjects', '{subject:s}', 'experiments',
+            '{experiment:s}', 'sessions', '{session:d}', 'ephys',
+            'current_processed', 'noreref', '{filename:s}'
+        )
 
+        # monopolar (old-format) HDF5 file
+        self.monopolar_file = self.eeg_path_template.format(
+            subject='R1275D',
+            experiment='FR1',
+            session=0,
+            timestamp='20170531_170954'
+        )
+
+        # bipolar (new-format) HDF5 file
+        self.bipolar_file = self.eeg_path_template.format(
+            subject='R1354E',
+            experiment='FR1',
+            session=0,
+            timestamp='20171026_160648'
+        )
+
+        self.raw_dataroot = osp.join(
+            root, 'protocols', 'r1', 'subjects', 'R1275D', 'experiments', 'FR1',
+            'sessions', '0', 'ephys', 'current_processed', 'noreref',
+            'R1275D_FR1_0_31May17_2109'
+        )
+        self.channels = np.array(['%.03d' % i for i in range(1, 10)])
+
+    @pytest.mark.only
     def test_h5reader_one_offset(self):
         channels = self.channels
-        h5_data,_ = H5RawReader.read_h5file(self.h5file, channels, [0], 1000)
+        with h5py.File(self.monopolar_file, 'r') as hfile:
+            h5_data, _ = H5RawReader.read_h5file(hfile, channels, [0], 1000)
 
         raw_timeseries,_ = BaseRawReader(dataroot=self.raw_dataroot,channels=channels,start_offsets=np.array([0]),read_size=1000).read()
         assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
 
     def test_h5reader_many_offsets(self):
-        offsets = np.arange(0,210000,3000)
-        h5_data,_ = H5RawReader.read_h5file(self.h5file, self.channels, offsets, 1000)
-        raw_timeseries,_ = BaseRawReader(dataroot=self.raw_dataroot,channels=self.channels,start_offsets=offsets,read_size=1000).read()
-        assert (raw_timeseries.data==h5_data*raw_timeseries.gain).all()
+        offsets = np.arange(0, 210000, 3000)
+
+        with h5py.File(self.monopolar_file, 'r') as hfile:
+            h5_data, _ = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
+        raw_timeseries, _ = BaseRawReader(dataroot=self.raw_dataroot, channels=self.channels, start_offsets=offsets, read_size=1000).read()
+        assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
 
     def test_h5reader_out_of_bounds(self):
-        offsets = np.arange(1000000,4000000,1000000)
-        h5_data,h5_mask = H5RawReader.read_h5file(self.h5file, self.channels, offsets, 1000)
+        offsets = np.arange(1000000, 4000000, 1000000)
+        with h5py.File(self.monopolar_file, 'r') as hfile:
+            h5_data, h5_mask = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
         raw_data,raw_mask = BaseRawReader(dataroot=self.raw_dataroot,channels=self.channels,start_offsets=offsets,read_size=1000).read()
-        assert(raw_mask==h5_mask).all()
-        assert(h5_data[h5_mask]==raw_data.data[raw_mask]).all()
+        assert(raw_mask == h5_mask).all()
+        assert(h5_data[h5_mask] == raw_data.data[raw_mask]).all()
 
     def test_h5reader_constructor(self):
-        dataroot = osp.join(get_rhino_root(),'scratch','ptsa_test', 'R1308T', 'experiments', 'FR1', 'sessions', '3',
-                            'ephys', 'current_processed','noreref','R1308T_FR1_3_13Jun17_1917.h5')
+        dataroot = self.dataroot_template.format(
+            subject='R1354E',
+            experiment='FR1',
+            session=0,
+            filename='R1354E_FR1_0_26Oct17_2006.h5'
+        )
         reader = H5RawReader(dataroot=dataroot, channels=np.array(['%.03d' % i for i in range(1, 10)]))
         reader.read()
         assert reader.channel_name == 'bipolar_pairs'

--- a/tests/test_h5reader.py
+++ b/tests/test_h5reader.py
@@ -14,23 +14,24 @@ from ptsa.test.utils import get_rhino_root, skip_without_rhino
 
 
 @skip_without_rhino
-class TestH5Reader(unittest.TestCase):
-    def setUp(self):
+class TestH5Reader:
+    @classmethod
+    def setup_class(cls):
         root = get_rhino_root()
-        self.eeg_path_template = osp.join(
+        cls.eeg_path_template = osp.join(
             root, 'data', 'eeg', '{subject:s}', 'behavioral', '{experiment:s}',
             'session_{session:d}', 'host_pc', '{timestamp:s}',
             'eeg_timeseries.h5'
         )
 
-        self.dataroot_template = osp.join(
+        cls.dataroot_template = osp.join(
             root, 'protocols', 'r1', 'subjects', '{subject:s}', 'experiments',
             '{experiment:s}', 'sessions', '{session:d}', 'ephys',
             'current_processed', 'noreref', '{filename:s}'
         )
 
         # monopolar (old-format) HDF5 file
-        self.monopolar_file = self.eeg_path_template.format(
+        cls.monopolar_file = cls.eeg_path_template.format(
             subject='R1275D',
             experiment='FR1',
             session=0,
@@ -38,35 +39,26 @@ class TestH5Reader(unittest.TestCase):
         )
 
         # bipolar (new-format) HDF5 file
-        self.bipolar_file = self.eeg_path_template.format(
+        cls.bipolar_file = cls.eeg_path_template.format(
             subject='R1354E',
             experiment='FR1',
             session=0,
             timestamp='20171026_160648'
         )
 
-        self.monopolar_dataroot = osp.join(
-            root, 'protocols', 'r1', 'subjects', 'R1275D', 'experiments', 'FR1',
-            'sessions', '0', 'ephys', 'current_processed', 'noreref',
-            'R1275D_FR1_0_31May17_2109'
+        cls.monopolar_dataroot = cls.dataroot_template.format(
+            subject='R1275D',
+            experiment='FR1',
+            session=0,
+            filename='R1275D_FR1_0_31May17_2109'
         )
-        self.channels = np.array(['%.03d' % i for i in range(1, 10)])
 
-    @pytest.mark.only
-    def test_h5reader_one_offset(self):
-        channels = self.channels
-        with h5py.File(self.monopolar_file, 'r') as hfile:
-            h5_data, _ = H5RawReader.read_h5file(hfile, channels, [0], 1000)
+        cls.channels = np.array(['%.03d' % i for i in range(1, 10)])
 
-        raw_timeseries, _ = BaseRawReader(dataroot=self.monopolar_dataroot,
-                                          channels=channels,
-                                          start_offsets=np.array([0]),
-                                          read_size=1000).read()
-        assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
-
-    def test_h5reader_many_offsets(self):
-        offsets = np.arange(0, 210000, 3000)
-
+    @pytest.mark.parametrize(
+        'offsets', [np.array([0]), np.arange(0, 210000, 3000)]
+    )
+    def test_with_offsets(self, offsets):
         with h5py.File(self.monopolar_file, 'r') as hfile:
             h5_data, _ = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
 
@@ -76,7 +68,8 @@ class TestH5Reader(unittest.TestCase):
                                           read_size=1000).read()
         assert (raw_timeseries.data == h5_data*raw_timeseries.gain).all()
 
-    def test_h5reader_out_of_bounds(self):
+    @pytest.mark.skip
+    def test_out_of_bounds(self):
         offsets = np.arange(1000000, 4000000, 1000000)
         with h5py.File(self.monopolar_file, 'r') as hfile:
             h5_data, h5_mask = H5RawReader.read_h5file(hfile, self.channels, offsets, 1000)
@@ -88,7 +81,8 @@ class TestH5Reader(unittest.TestCase):
         assert(raw_mask == h5_mask).all()
         assert(h5_data[h5_mask] == raw_data.data[raw_mask]).all()
 
-    def test_h5reader_constructor(self):
+    @pytest.mark.skip
+    def test_constructor(self):
         dataroot = self.dataroot_template.format(
             subject='R1354E',
             experiment='FR1',
@@ -99,36 +93,40 @@ class TestH5Reader(unittest.TestCase):
         reader.read()
         assert reader.channel_name == 'bipolar_pairs'
 
+    @pytest.mark.skip
     def test_with_events(self):
         dataroot_format = osp.join(get_rhino_root(),'scratch','ptsa_test','R1308T', 'experiments', 'FR1', 'sessions', '3',
                                    'behavioral','current_processed','task_events.json')
         events = CMLEventReader(filename=dataroot_format).read()[:20]
         EEGReader(events=events,channels=np.array(['%.03d'%i for i in range(1,10)]),start_time=0.0,end_time=0.5).read()
 
+    @pytest.mark.skip
     def test_h5reader_empty_channels(self):
         dataroot_format = osp.join(get_rhino_root(),'scratch','ptsa_test','R1308T', 'experiments', 'FR1', 'sessions', '3',
                                    'behavioral','current_processed','task_events.json')
         events = CMLEventReader(filename=dataroot_format).read()[:20]
-        eeg = EEGReader(events=events,channels=np.array([]),start_time=0.0,end_time=0.5).read()
-        assert len(eeg.bipolar_pairs)>0
+        eeg = EEGReader(events=events, channels=np.array([]),
+                        start_time=0.0, end_time=0.5).read()
+        assert len(eeg.bipolar_pairs) > 0
 
     @pytest.mark.skip
     @pytest.mark.slow
-    def test_h5_reader_timing(self):
+    def test_timing(self):
         channels = np.array(['%.03d' % i for i in range(1, 100)])
-        tic=time.time()
-        h5_data,_ = H5RawReader.read_h5file(self.h5_dataroot, channels=channels)
+        tic = time.time()
+        h5_data, _ = H5RawReader.read_h5file(self.h5_dataroot, channels=channels)
         toc = time.time()
         del h5_data
         h5dur = toc-tic
-        tic=time.time()
-        raw_data,_ = BaseRawReader(dataroot=self.monopolar_dataroot, channels=channels).read()
-        toc=time.time()
+        tic = time.time()
+        raw_data, _ = BaseRawReader(dataroot=self.monopolar_dataroot,
+                                   channels=channels).read()
+        toc = time.time()
         del raw_data
         rawdur = toc-tic
         print('h5 file read in %s seconds'%h5dur)
         print('raw files read in %s seconds'%rawdur)
-        assert h5dur<=rawdur
+        assert h5dur <= rawdur
 
 
 


### PR DESCRIPTION
We are already using `h5py` elsewhere so reading EEG data stored in HDF5 format should use that instead of PyTables to avoid a needless extra requirement.

Addresses #92.