### PR TITLE
Update requirements for building conda packages

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,22 +14,22 @@ requirements:
   build:
     - python {{ python }}
     - numpy
-    - scipy
-    - xarray
     - pywavelets
-    - swig
     - pytables
     - setuptools
+    - scipy
+    - swig
+    - xarray
 
   run:
     - python {{ python }}
-    - numpy
-    - scipy
-    - xarray
     - h5py
+    - numpy
     - pywavelets
     - pytables
+    - scipy
     - vs2015_runtime  [win]
+    - xarray
 
 test:
   # Test that we can import ptsa and its extension modules

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - numpy
     - scipy
     - xarray
+    - h5py
     - pywavelets
     - pytables
     - vs2015_runtime  [win]


### PR DESCRIPTION
Addresses #115.

It would also be good to include pybind11 here somehow, but it's not clear yet if that's possible (since it is not on the default channel and we don't necessarily want to be building using everything in conda-forge).