### PR TITLE
Use pip to install pybind11 for conda package

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,2 +1,4 @@
+pip install pybind11
+if errorlevel 1 exit 1
 "%PYTHON%" setup.py install
 if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -7,4 +7,6 @@ if [[ "$UNAME" == 'Darwin' ]]; then
    export LIBRARY_PATH=/usr/local/lib;
 fi
 
+# FIXME: figure out how to depend on conda-forge package of this only
+pip install pybind11
 $PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
   build:
     - python {{ python }}
     - numpy
+    - pip
     - pywavelets
     - pytables
     - setuptools


### PR DESCRIPTION
This is a temporary workaround until a meta.yaml-specific solution
can be found.