### PR TITLE
Improve EDFFile

### DIFF
--- a/ptsa/extensions/edf/edffile.cpp
+++ b/ptsa/extensions/edf/edffile.cpp
@@ -45,20 +45,6 @@ private:
         }
     }
 
-public:
-    /**
-     * Open an EDF file for reading.
-     * @param filename
-     * @throws std::runtime_error when the EDF file cannot be opened
-     */
-    EDFFile(std::string filename) {
-        this->open(filename);
-    }
-
-    ~EDFFile() {
-        this->close();
-    }
-
     /**
      * Open an EDF file.
      * @param filename
@@ -91,6 +77,20 @@ public:
                 throw std::runtime_error(msg);
             }
         }
+    }
+
+public:
+    /**
+     * Open an EDF file for reading.
+     * @param filename
+     * @throws std::runtime_error when the EDF file cannot be opened
+     */
+    EDFFile(std::string filename) {
+        this->open(filename);
+    }
+
+    ~EDFFile() {
+        this->close();
     }
 
     /**

--- a/ptsa/extensions/edf/edffile.cpp
+++ b/ptsa/extensions/edf/edffile.cpp
@@ -30,6 +30,9 @@ class EDFFile
 private:
     struct edf_hdr_struct header;
 
+    /// Keeps track of whether or not the file is open
+    bool opened{ false };
+
     inline int handle() {
         return this->header.handle;
     }
@@ -77,6 +80,10 @@ private:
                 throw std::runtime_error(msg);
             }
         }
+        else
+        {
+            this->opened = true;
+        }
     }
 
 public:
@@ -89,15 +96,24 @@ public:
         this->open(filename);
     }
 
-    ~EDFFile() {
-        this->close();
+    ~EDFFile()
+    {
+        if (this->opened) {
+            this->close();
+        }
     }
 
     /**
      * Close the EDF file.
      */
-    void close() {
-        edfclose_file(this->handle());
+    void close()
+    {
+        if (edfclose_file(this->handle() < 0)) {
+            throw std::runtime_error("Error closing EDF file!");
+        }
+        else {
+            this->opened = false;
+        }
     }
 
     /**

--- a/ptsa/extensions/edf/edffile.cpp
+++ b/ptsa/extensions/edf/edffile.cpp
@@ -86,6 +86,16 @@ private:
         }
     }
 
+    /**
+     * Call to check that the file is opened. Throws an exception if not.
+     */
+    inline void ensure_open()
+    {
+        if (!this->opened) {
+            throw std::runtime_error("EDF file is not opened!");
+        }
+    }
+
 public:
     /**
      * Open an EDF file for reading.
@@ -131,6 +141,7 @@ public:
      */
     inline ChannelInfo get_channel_info(int channel)
     {
+        ensure_open();
         if (channel >= this->header.edfsignals)
         {
             const auto msg = "Channl " + std::to_string(channel) + " out of range";
@@ -147,15 +158,19 @@ public:
      */
     inline long long get_num_samples(int channel)
     {
+        ensure_open();
         return this->header.signalparam[channel].smp_in_file;
     }
 
     inline long long get_num_samples()
     {
+        ensure_open();
         return this->get_num_samples(0);
     }
 
-    inline long long get_num_annotations() {
+    inline long long get_num_annotations()
+    {
+        ensure_open();
         return this->header.annotations_in_file;
     }
 
@@ -165,6 +180,7 @@ public:
      */
     struct edf_annotation_struct get_annotation(int index)
     {
+        ensure_open();
         struct edf_annotation_struct annotation;
         edf_get_annotation(this->header.handle, index, &annotation);
         return annotation;
@@ -199,6 +215,8 @@ public:
      */
     py::array_t<int> read_samples(std::vector<int> channels, int n_samples, long long offset)
     {
+        ensure_open();
+
         const std::vector<ssize_t> shape = {{static_cast<long>(channels.size()), n_samples}};
         auto output = py::array_t<int>(shape);
         auto info = output.request();

--- a/ptsa/extensions/edf/edffile.cpp
+++ b/ptsa/extensions/edf/edffile.cpp
@@ -257,12 +257,12 @@ PYBIND11_MODULE(edffile, m)
 
     )")
         .def(py::init<const std::string &>())
-        .def("__enter__", [](EDFFile &self) {
-            return self;  // FIXME: this doesn't seem to work...
-        })
-        .def("__exit__", [](EDFFile &self, py::object type, py::object value, py::object tb) {
-            self.close();
-        })
+        // .def("__enter__", [](EDFFile &self) {
+        //     return self;  // FIXME: this doesn't seem to work...
+        // })
+        // .def("__exit__", [](EDFFile &self, py::object type, py::object value, py::object tb) {
+        //     self.close();
+        // })
         .def_property_readonly("num_channels", &EDFFile::get_num_channels)
         .def_property_readonly("num_samples", [](EDFFile &self) {
             return self.get_num_samples(0);


### PR DESCRIPTION
- Remove context manager functionality (since this wasn't working)
- Conditionally close files (i.e., only close when actually open)
- Ensure file is opened when using methods that require an open file