### PR TITLE
Refactor filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
   - "3.5"
   - "3.6"
 notifications:
@@ -13,11 +12,7 @@ env:
 install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r

--- a/ptsa/data/filters/base.py
+++ b/ptsa/data/filters/base.py
@@ -1,4 +1,3 @@
-import numpy as np
 import traits.api
 
 from ptsa.data.timeseries import TimeSeries
@@ -7,62 +6,48 @@ __all__ = ['BaseFilter']
 
 
 class BaseFilter(traits.api.HasTraits):
-    """Base class for constructing filters.
+    """Base class for constructing filters."""
+    nontime_dims = traits.api.Tuple
+    nontime_sizes = traits.api.Tuple
 
-    Parameters
-    ----------
-    timeseries : TimeSeries or None
-        The :class:`TimeSeries` to filter (None to set later).
-    args
-        Arguments that get passed on to :meth:`initialize`.
-
-    Keyword arguments
-    -----------------
-    dtype : str or np.dtype or None
-        When given, coerce the input to a valid numpy dtype. When ``None``,
-        leave as the original dtype. Default: coerce to ``np.float64``.
-    kwargs
-        Additional keyword arguments that get passed on to :meth:`initialize`.
-
-    Notes
-    -----
-    Do not override the :meth:`__init__` method. Instead, perform
-    filter-specific initialization in the :meth:`initialize` method.
-
-    """
-    _timeseries = traits.api.Instance(TimeSeries)
-
-    def __init__(self, timeseries, *args, **kwargs):
+    def __init__(self):
         super(BaseFilter, self).__init__()
 
-        self._dtype = kwargs.pop("dtype", np.float64)
-        self.timeseries = timeseries
+    def get_nontime_dims(self, timeseries):
+        """Return a tuple of all dimensions that are not time.
 
-        self.nontime_dims = tuple([d for d in self.timeseries.dims if d != 'time'])
-        self.nontime_sizes = tuple([len(self.timeseries[d]) for d in self.nontime_dims])
-
-        self.initialize(*args, **kwargs)
-
-    def initialize(self, *args, **kwargs):
-        """Override this method to include additional filter-specific
-        initialization steps.
+        Returns
+        -------
+        Tuple[str]
 
         """
+        return tuple([d for d in timeseries.dims if d != 'time'])
 
-    @property
-    def timeseries(self):
-        return self._timeseries
+    def get_nontime_sizes(self, timeseries):
+        """Return a tuple of all dimension sizes for dimensions other than
+        time.
 
-    @timeseries.setter
-    def timeseries(self, ts):
-        """Set the time series data and coerce types if neccessary."""
-        if ts is None:
-            self._timeseries = None
-            return
+        Returns
+        -------
+        Tuple[int]
 
-        self._timeseries = ts
-        if self._dtype is not None:
-            self._timeseries.data = ts.data.astype(self._dtype)
+        """
+        dims = self.get_nontime_dims(timeseries)
+        return tuple([len(timeseries[dim]) for dim in dims])
 
-    def filter(self):
+    def filter(self, timeseries):
+        """Apply the filter.
+
+        Parameters
+        ----------
+        timeseries : TimeSeries
+
+        Notes
+        -----
+        Some filters may require certain numpy datatypes to work. To coerce to
+        the proper datatype, use :meth:`TimeSeries.coerce_to` when implementing
+        this method.
+
+        """
         raise NotImplementedError
+

--- a/ptsa/data/filters/base.py
+++ b/ptsa/data/filters/base.py
@@ -11,25 +11,58 @@ class BaseFilter(traits.api.HasTraits):
 
     Parameters
     ----------
-    timeseries : TimeSeries
-        The :class:`TimeSeries` to filter.
+    timeseries : TimeSeries or None
+        The :class:`TimeSeries` to filter (None to set later).
+    args
+        Arguments that get passed on to :meth:`initialize`.
+
+    Keyword arguments
+    -----------------
     dtype : str or np.dtype or None
         When given, coerce the input to a valid numpy dtype. When ``None``,
         leave as the original dtype. Default: coerce to ``np.float64``.
+    kwargs
+        Additional keyword arguments that get passed on to :meth:`initialize`.
+
+    Notes
+    -----
+    Do not override the :meth:`__init__` method. Instead, perform
+    filter-specific initialization in the :meth:`initialize` method.
 
     """
-    timeseries = traits.api.Instance(TimeSeries)
+    _timeseries = traits.api.Instance(TimeSeries)
 
-    def __init__(self, timeseries, dtype=np.float64):
+    def __init__(self, timeseries, *args, **kwargs):
         super(BaseFilter, self).__init__()
 
+        self._dtype = kwargs.pop("dtype", np.float64)
         self.timeseries = timeseries
-
-        if dtype is not None:
-            self.timeseries.data = timeseries.data.astype(dtype)
 
         self.nontime_dims = tuple([d for d in self.timeseries.dims if d != 'time'])
         self.nontime_sizes = tuple([len(self.timeseries[d]) for d in self.nontime_dims])
+
+        self.initialize(*args, **kwargs)
+
+    def initialize(self, *args, **kwargs):
+        """Override this method to include additional filter-specific
+        initialization steps.
+
+        """
+
+    @property
+    def timeseries(self):
+        return self._timeseries
+
+    @timeseries.setter
+    def timeseries(self, ts):
+        """Set the time series data and coerce types if neccessary."""
+        if ts is None:
+            self._timeseries = None
+            return
+
+        self._timeseries = ts
+        if self._dtype is not None:
+            self._timeseries.data = ts.data.astype(self._dtype)
 
     def filter(self):
         raise NotImplementedError

--- a/ptsa/data/filters/butterworth.py
+++ b/ptsa/data/filters/butterworth.py
@@ -30,9 +30,7 @@ class ButterworthFilter(BaseFilter):
     freq_range = traits.api.CList(maxlen=2)
     filt_type = traits.api.Str
 
-    def __init__(self, timeseries, freq_range, order=4, filt_type='stop'):
-        super(ButterworthFilter, self).__init__(timeseries)
-
+    def initialize(self, freq_range, order=4, filt_type="stop"):
         self.freq_range = freq_range
         self.order = order
         self.filt_type = filt_type
@@ -61,6 +59,5 @@ class ButterworthFilter(BaseFilter):
             coords=coords_dict
         )
 
-        # filtered_timeseries = TimeSeries(filtered_timeseries)
         filtered_timeseries.attrs = self.timeseries.attrs.copy()
         return filtered_timeseries

--- a/ptsa/data/filters/butterworth.py
+++ b/ptsa/data/filters/butterworth.py
@@ -30,12 +30,13 @@ class ButterworthFilter(BaseFilter):
     freq_range = traits.api.CList(maxlen=2)
     filt_type = traits.api.Str
 
-    def initialize(self, freq_range, order=4, filt_type="stop"):
+    def __init__(self, freq_range, order=4, filt_type="stop"):
+        super().__init__()
         self.freq_range = freq_range
         self.order = order
         self.filt_type = filt_type
 
-    def filter(self):
+    def filter(self, timeseries):
         """
         Applies Butterwoth filter to input time series and returns filtered TimeSeriesX object
 
@@ -45,19 +46,19 @@ class ButterworthFilter(BaseFilter):
             The filtered time series
 
         """
-        time_axis_index = get_axis_index(self.timeseries, axis_name='time')
-        filtered_array = buttfilt(self.timeseries,
-                                  self.freq_range, float(self.timeseries['samplerate']), self.filt_type,
+        time_axis_index = get_axis_index(timeseries, axis_name='time')
+        filtered_array = buttfilt(timeseries,
+                                  self.freq_range, float(timeseries['samplerate']), self.filt_type,
                                   self.order, axis=time_axis_index)
 
-        coords_dict = {coord_name: DataArray(coord.copy()) for coord_name, coord in list(self.timeseries.coords.items())}
-        coords_dict['samplerate'] = self.timeseries['samplerate']
-        dims = [dim_name for dim_name in self.timeseries.dims]
+        coords_dict = {coord_name: DataArray(coord.copy()) for coord_name, coord in list(timeseries.coords.items())}
+        coords_dict['samplerate'] = timeseries['samplerate']
+        dims = [dim_name for dim_name in timeseries.dims]
         filtered_timeseries = TimeSeries(
             filtered_array,
             dims=dims,
             coords=coords_dict
         )
 
-        filtered_timeseries.attrs = self.timeseries.attrs.copy()
+        filtered_timeseries.attrs = timeseries.attrs.copy()
         return filtered_timeseries

--- a/ptsa/data/filters/data_chopper.py
+++ b/ptsa/data/filters/data_chopper.py
@@ -1,9 +1,7 @@
-__author__ = 'm'
-
 import numpy as np
-
-import xarray as xr
 import traits.api
+import xarray as xr
+
 from ptsa.data.timeseries import TimeSeries
 
 
@@ -20,17 +18,10 @@ class DataChopper(traits.api.HasTraits):
     start_offsets = traits.api.CArray
     timeseries=traits.api.Instance(TimeSeries)
 
-
-
-    def __init__(self, timeseries, start_time=0.0, end_time=0.0, buffer_time=0.0,
-                 events=np.recarray((1,), dtype=[('x', int)]),
-                 start_offsets = np.array([], dtype=int)):
+    def initialize(self, start_time=0.0, end_time=0.0, buffer_time=0.0,
+                   events=np.recarray((1,), dtype=[('x', int)]),
+                   start_offsets=np.array([], dtype=int)):
         """
-        Constructor:
-
-        :param kwds:allowed values are:
-        -------------------------------------
-        :param timeseries {TimeSeries}-  TimeSeries object with eeg session data
         :param start_time {float} -  read start offset in seconds w.r.t to the eegeffset specified in the events recarray
         :param end_time {float} -  read end offset in seconds w.r.t to the eegeffset specified in the events recarray
         :param end_time {float} -  extra buffer in seconds (subtracted from start read and added to end read)
@@ -39,13 +30,12 @@ class DataChopper(traits.api.HasTraits):
 
 
         :return: None
-        
-        .. versionchanged:: 2.0
-        Parameter "time_series" was renamed to "timeseries".
-        """
-        super(DataChopper, self).__init__()
 
-        self.timeseries=timeseries
+        .. versionchanged:: 2.0
+
+            Parameter "time_series" was renamed to "timeseries".
+
+        """
         self.start_time = start_time
         self.end_time = end_time
         self.buffer_time = buffer_time
@@ -96,7 +86,7 @@ class DataChopper(traits.api.HasTraits):
             chopping_axis_name = 'events'
             chopping_axis_data = evs
 
-            
+
         samplerate = float(self.timeseries['samplerate'])
         offset_time_array = self.timeseries['offsets']
 

--- a/ptsa/data/filters/data_chopper.py
+++ b/ptsa/data/filters/data_chopper.py
@@ -2,10 +2,11 @@ import numpy as np
 import traits.api
 import xarray as xr
 
+from . import BaseFilter
 from ptsa.data.timeseries import TimeSeries
 
 
-class DataChopper(traits.api.HasTraits):
+class DataChopper(BaseFilter):
     """
     EventDataChopper converts continuous time series of entire session into chunks based on the events specification
     In other words you may read entire eeg session first and then using EventDataChopper
@@ -18,9 +19,9 @@ class DataChopper(traits.api.HasTraits):
     start_offsets = traits.api.CArray
     timeseries=traits.api.Instance(TimeSeries)
 
-    def initialize(self, start_time=0.0, end_time=0.0, buffer_time=0.0,
-                   events=np.recarray((1,), dtype=[('x', int)]),
-                   start_offsets=np.array([], dtype=int)):
+    def __init__(self, start_time=0.0, end_time=0.0, buffer_time=0.0,
+                 events=np.recarray((1,), dtype=[('x', int)]),
+                 start_offsets=np.array([], dtype=int)):
         """
         :param start_time {float} -  read start offset in seconds w.r.t to the eegeffset specified in the events recarray
         :param end_time {float} -  read end offset in seconds w.r.t to the eegeffset specified in the events recarray
@@ -36,6 +37,7 @@ class DataChopper(traits.api.HasTraits):
             Parameter "time_series" was renamed to "timeseries".
 
         """
+        super().__init__()
         self.start_time = start_time
         self.end_time = end_time
         self.buffer_time = buffer_time
@@ -67,7 +69,7 @@ class DataChopper(traits.api.HasTraits):
 
         return len(selector_array), start_point_shift
 
-    def filter(self):
+    def filter(self, timeseries):
         """
         Chops session into chunks corresponding to events
         :return: TimeSeries object with chopped session
@@ -81,19 +83,20 @@ class DataChopper(traits.api.HasTraits):
             chopping_axis_data = start_offsets
         else:
 
-            evs = self.events[self.events.eegfile == self.timeseries.attrs['dataroot']]
+            evs = self.events[self.events.eegfile == timeseries.attrs['dataroot']]
             start_offsets = evs.eegoffset
             chopping_axis_name = 'events'
             chopping_axis_data = evs
 
 
-        samplerate = float(self.timeseries['samplerate'])
-        offset_time_array = self.timeseries['offsets']
+        samplerate = float(timeseries['samplerate'])
+        offset_time_array = timeseries['offsets']
 
         event_chunk_size, start_point_shift = self.get_event_chunk_size_and_start_point_shift(
-        eegoffset=start_offsets[0],
-        samplerate=samplerate,
-        offset_time_array=offset_time_array)
+            eegoffset=start_offsets[0],
+            samplerate=samplerate,
+            offset_time_array=offset_time_array
+        )
 
 
         event_time_axis = np.arange(event_chunk_size)*(1.0/samplerate)+(self.start_time-self.buffer_time)
@@ -106,7 +109,7 @@ class DataChopper(traits.api.HasTraits):
             start_chop_pos += start_point_shift
             selector_array = np.arange(start=start_chop_pos, stop=start_chop_pos + event_chunk_size)
 
-            chopped_data_array = self.timeseries.isel(time=selector_array)
+            chopped_data_array = timeseries.isel(time=selector_array)
 
             chopped_data_array['time'] = event_time_axis
             chopped_data_array['start_offsets'] = [i]

--- a/ptsa/data/filters/monopolar_to_bipolar_mapper.py
+++ b/ptsa/data/filters/monopolar_to_bipolar_mapper.py
@@ -1,12 +1,8 @@
-__author__ = 'm'
-
 import numpy as np
-from ptsa.data.timeseries import TimeSeries
-# from memory_profiler import profile
-import time
-
-from ptsa.data.filters import BaseFilter
 import traits.api
+
+from ptsa.data.timeseries import TimeSeries
+from ptsa.data.filters import BaseFilter
 
 
 class MonopolarToBipolarMapper(BaseFilter):
@@ -35,17 +31,19 @@ class MonopolarToBipolarMapper(BaseFilter):
         two channels in the bipolar pair
 
     .. versionchanged:: 2.0
-    Parameter "time_series" was renamed to "timeseries".
-    Support for 2-D bipolar_pairs and specification of channels_dim
-    and chan_names was added in version 2.0.
+
+        Parameter "time_series" was renamed to "timeseries".
+        Support for 2-D bipolar_pairs and specification of channels_dim
+        and chan_names was added in version 2.0.
+
     """
+    bipolar_pairs = traits.api.Array()
+    channels_dim = traits.api.String()
+    chan_names = traits.api.ListStr()
 
-    # bipolar_pairs = traits.api.Array(dtype=[('ch0', '|S3'), ('ch1', '|S3')])
-
-    def __init__(self, timeseries, bipolar_pairs, channels_dim='channels',
-                 chan_names=['ch0', 'ch1']):
-        super(MonopolarToBipolarMapper, self).__init__(timeseries)
-        if (len(np.shape(bipolar_pairs)) == 2):
+    def initialize(self, bipolar_pairs, channels_dim="channels",
+                   chan_names=["ch0", "ch1"]):
+        if len(np.shape(bipolar_pairs)) == 2:
             if np.shape(bipolar_pairs)[0] == 2:
                 self.bipolar_pairs = np.core.records.fromarrays(
                     bipolar_pairs, names=chan_names)

--- a/ptsa/data/filters/monopolar_to_bipolar_mapper.py
+++ b/ptsa/data/filters/monopolar_to_bipolar_mapper.py
@@ -41,8 +41,10 @@ class MonopolarToBipolarMapper(BaseFilter):
     channels_dim = traits.api.String()
     chan_names = traits.api.ListStr()
 
-    def initialize(self, bipolar_pairs, channels_dim="channels",
-                   chan_names=["ch0", "ch1"]):
+    def __init__(self, bipolar_pairs, channels_dim="channels",
+                 chan_names=["ch0", "ch1"]):
+        super().__init__()
+
         if len(np.shape(bipolar_pairs)) == 2:
             if np.shape(bipolar_pairs)[0] == 2:
                 self.bipolar_pairs = np.core.records.fromarrays(
@@ -53,14 +55,14 @@ class MonopolarToBipolarMapper(BaseFilter):
                     'dtypes has two fields corresponding to chan_names or a 2-D'
                     'container where the first dimension must be length 2'
                     'corresponding to the two channels in the bipolar pair.'
-                    'Input was 2-D with the following dimensions: '+
+                    'Input was 2-D with the following dimensions: ' +
                     str(np.shape(bipolar_pairs)))
         else:
             self.bipolar_pairs = bipolar_pairs
         self.channels_dim = channels_dim
         self.chan_names = chan_names
 
-    def filter(self):
+    def filter(self, timeseries):
         """Apply the constructed filter.
 
         Returns
@@ -68,7 +70,7 @@ class MonopolarToBipolarMapper(BaseFilter):
         A TimeSeries object.
 
         """
-        channel_axis = self.timeseries[self.channels_dim]
+        channel_axis = timeseries[self.channels_dim]
 
         ch0 = self.bipolar_pairs[self.chan_names[0]]
         ch1 = self.bipolar_pairs[self.chan_names[1]]
@@ -76,20 +78,21 @@ class MonopolarToBipolarMapper(BaseFilter):
         sel0 = channel_axis.loc[ch0]
         sel1 = channel_axis.loc[ch1]
 
-        ts0 = self.timeseries.loc[{self.channels_dim: sel0}]
-        ts1 = self.timeseries.loc[{self.channels_dim: sel1}]
+        ts0 = timeseries.loc[{self.channels_dim: sel0}]
+        ts1 = timeseries.loc[{self.channels_dim: sel1}]
 
-        dims_bp = list(self.timeseries.dims)
+        dims_bp = list(timeseries.dims)
 
-        coords_bp = {coord_name:coord
-                     for coord_name, coord in list(
-                             self.timeseries.coords.items())}
+        coords_bp = {
+            coord_name: coord
+            for coord_name, coord in list(timeseries.coords.items())
+        }
         coords_bp[self.channels_dim] = self.bipolar_pairs
 
         ts = TimeSeries(data=ts0.values - ts1.values, dims=dims_bp,
                         coords=coords_bp)
-        ts['samplerate'] = self.timeseries['samplerate']
+        ts['samplerate'] = timeseries['samplerate']
 
-        ts.attrs = self.timeseries.attrs.copy()
-        ts.name = self.timeseries.name
+        ts.attrs = timeseries.attrs.copy()
+        ts.name = timeseries.name
         return ts

--- a/ptsa/data/filters/morlet.py
+++ b/ptsa/data/filters/morlet.py
@@ -28,7 +28,7 @@ class MorletWaveletFilter(BaseFilter):
         The frequencies to use in the decomposition
     width: int
         The width of the wavelet
-    output: List[str] or str
+    output: Union[Iterable[str], str]
         A string or a list of strings containing power, phase, and/or
         complex (default: ``['power', 'phase']``)
     verbose: bool
@@ -44,11 +44,11 @@ class MorletWaveletFilter(BaseFilter):
     width = traits.api.Int
     verbose = traits.api.Bool
     cpus = traits.api.Int
+    output = []
+    output_dim = traits.api.Str
 
-    def __init__(self, timeseries, freqs, width=5,
-                 output=('power', 'phase'), verbose=True, cpus=1,
-                 output_dim='output'):
-        super(MorletWaveletFilter, self).__init__(timeseries)
+    def initialize(self, freqs, width=5, output=('power', 'phase'),
+                   verbose=True, cpus=1, output_dim='output'):
         self.freqs = freqs
         self.width = width
 
@@ -69,10 +69,7 @@ class MorletWaveletFilter(BaseFilter):
 
         self.verbose = verbose
         self.cpus = cpus
-        self.window = None
         self.output_dim = output_dim
-
-        self.compute_power_and_phase_fcn = None
 
     def filter(self):
         """Apply the constructed filter."""

--- a/ptsa/data/filters/morlet.py
+++ b/ptsa/data/filters/morlet.py
@@ -78,7 +78,7 @@ class MorletWaveletFilter(BaseFilter):
         nontime_dims = self.get_nontime_dims(timeseries)
         nontime_sizes = self.get_nontime_sizes(timeseries)
 
-        wavelet_dims = nontime_sizes(timeseries) + (self.freqs.shape[0],)
+        wavelet_dims = nontime_sizes + (self.freqs.shape[0],)
 
         powers_reshaped = np.array([[]], dtype=np.float)
         phases_reshaped = np.array([[]], dtype=np.float)
@@ -87,22 +87,22 @@ class MorletWaveletFilter(BaseFilter):
         if 'power' in self.output:
             powers_reshaped = np.empty(
                 shape=(np.prod(wavelet_dims),
-                       len(self.timeseries['time'])), dtype=np.float)
+                       len(timeseries['time'])), dtype=np.float)
         if 'phase' in self.output:
             phases_reshaped = np.empty(
                 shape=(np.prod(wavelet_dims),
-                       len(self.timeseries['time'])), dtype=np.float)
+                       len(timeseries['time'])), dtype=np.float)
         if 'complex' in self.output:
             wavelets_complex_reshaped = np.empty(
-                shape=(np.prod(wavelet_dims), len(self.timeseries['time'])),
+                shape=(np.prod(wavelet_dims), len(timeseries['time'])),
                 dtype=np.complex)
 
         mt = morlet.MorletWaveletTransformMP(self.cpus)
 
         timeseries_reshaped = np.ascontiguousarray(
-            self.timeseries.data.reshape(
+            timeseries.data.reshape(
                 np.prod(nontime_sizes, dtype=int),
-                len(self.timeseries['time'])), self.timeseries.data.dtype)
+                len(timeseries['time'])), timeseries.data.dtype).astype(np.float64)
 
         if self.output == ['power']:
             mt.set_output_type(morlet.POWER)
@@ -120,7 +120,7 @@ class MorletWaveletFilter(BaseFilter):
         mt.set_wavelet_phase_array(phases_reshaped)
         mt.set_wavelet_complex_array(wavelets_complex_reshaped)
 
-        mt.initialize_signal_props(float(self.timeseries['samplerate']))
+        mt.initialize_signal_props(float(timeseries['samplerate']))
         mt.initialize_wavelet_props(self.width, self.freqs)
         mt.prepare_run()
 
@@ -132,13 +132,13 @@ class MorletWaveletFilter(BaseFilter):
         wavelet_complex_final = None
 
         if 'power' in self.output:
-            powers_final = powers_reshaped.reshape(wavelet_dims + (len(self.timeseries['time']),))
+            powers_final = powers_reshaped.reshape(wavelet_dims + (len(timeseries['time']),))
         if 'phase' in self.output:
-            phases_final = phases_reshaped.reshape(wavelet_dims + (len(self.timeseries['time']),))
+            phases_final = phases_reshaped.reshape(wavelet_dims + (len(timeseries['time']),))
         if 'complex' in self.output:
-            wavelet_complex_final = wavelets_complex_reshaped.reshape(wavelet_dims + (len(self.timeseries['time']),))
+            wavelet_complex_final = wavelets_complex_reshaped.reshape(wavelet_dims + (len(timeseries['time']),))
 
-        coords = {k: v for k, v in list(self.timeseries.coords.items())}
+        coords = {k: v for k, v in list(timeseries.coords.items())}
         coords['frequency'] = self.freqs
 
         powers_ts = None

--- a/ptsa/data/filters/resample.py
+++ b/ptsa/data/filters/resample.py
@@ -48,7 +48,7 @@ class ResampleFilter(BaseFilter):
             resampled time series with sampling frequency set to resamplerate
 
         """
-        timeseries = timeseries.coerce_to_dtype(timeseries, np.float64)
+        timeseries.coerce_to(np.float64)
         samplerate = float(timeseries['samplerate'])
 
         self.time_axis_index = timeseries.get_axis_num(

--- a/ptsa/data/filters/resample.py
+++ b/ptsa/data/filters/resample.py
@@ -1,24 +1,16 @@
 import numpy as np
 from scipy.signal import resample
+import traits.api
 
 from ptsa.data.timeseries import TimeSeries
 from ptsa.data.filters import BaseFilter
-import traits.api
 
 
 class ResampleFilter(BaseFilter):
-    """Upsample or downsample a time series to a new sample rate.
+    """Resample a time series to a new sample rate.
 
-    .. versionchanged:: 2.0
-
-        Parameter "time_series" was renamed to "timeseries". Parameter
-        "time_axis_index" was removed; the time axis is assumed to be named
-        "time"
-
-    Keyword Arguments
-    -----------------
-    timeseries
-        TimeSeries object
+    Parameters
+    ----------
     resamplerate: float
         new sampling frequency
     round_to_original_timepoints: bool
@@ -27,14 +19,21 @@ class ResampleFilter(BaseFilter):
     time_axis: str
         Name of the time axis.
 
+    .. versionchanged:: 2.0
+
+        Parameter "time_series" was renamed to "timeseries". Parameter
+        "time_axis_index" was removed; the time axis is assumed to be named
+        "time"
+
     """
 
     resamplerate = traits.api.CFloat
     round_to_original_timepoints = traits.api.Bool
+    time_axis_name = traits.api.Str
+    time_axis_index = traits.api.Int
 
-    def __init__(self, timeseries, resamplerate,
-                 round_to_original_timepoints=False, time_axis_name='time'):
-        super(ResampleFilter, self).__init__(timeseries=timeseries)
+    def initialize(self, resamplerate, round_to_original_timepoints=False,
+                   time_axis_name="time"):
         self.resamplerate = resamplerate
         self.round_to_original_timepoints = round_to_original_timepoints
         self.time_axis_name = time_axis_name

--- a/ptsa/data/timeseries.py
+++ b/ptsa/data/timeseries.py
@@ -79,6 +79,14 @@ class TimeSeries(xr.DataArray):
             coords['samplerate'] = float(samplerate)
         return cls(data, coords=coords, dims=dims, name=name, attrs=attrs)
 
+    def coerce_to(self, dtype=np.float64):
+        """Coerce the data to the specified dtype in place. If dtype is None,
+        this method does nothing. Default: coerce to ``np.float64``.
+
+        """
+        if dtype is not None:
+            self.data = self.data.astype(dtype)
+
     def to_hdf(self, filename, mode='w', compression=None,
                compression_opts=None, encode_string_arrays=True,
                encoding='utf8'):

--- a/ptsa/data/timeseries.py
+++ b/ptsa/data/timeseries.py
@@ -429,7 +429,7 @@ class TimeSeries(xr.DataArray):
         if not issubclass(filter_class, BaseFilter):
             raise TypeError("filter_class must be a child of BaseFilter")
 
-        filtered = filter_class(self, **kwargs).filter()
+        filtered = filter_class(**kwargs).filter(self)
         return filtered
 
     def filtered(self, freq_range, filt_type='stop', order=4):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -28,15 +28,13 @@ def test_monopolar_to_bipolar_filter_norhino():
         dims=dims, name="test", attrs={'test_attr': 1})
 
     bipolar_pairs1 = np.array([range(9), range(1,10)])
-    m2b1 = MonopolarToBipolarMapper(timeseries=ts,
-                                    bipolar_pairs=bipolar_pairs1)
-    ts_m2b1 = m2b1.filter()
+    m2b1 = MonopolarToBipolarMapper(bipolar_pairs=bipolar_pairs1)
+    ts_m2b1 = m2b1.filter(ts)
 
     bipolar_pairs2 = np.array([(i, j) for i, j in zip(range(9), range(1,10))],
                               dtype=[('ch0', '<i8'), ('ch1', '<i8')])
-    m2b2 = MonopolarToBipolarMapper(timeseries=ts,
-                                    bipolar_pairs=bipolar_pairs2)
-    ts_m2b2 = m2b2.filter()
+    m2b2 = MonopolarToBipolarMapper(bipolar_pairs=bipolar_pairs2)
+    ts_m2b2 = m2b2.filter(ts)
 
     assert np.all(ts_m2b1 == ts_m2b2)
 
@@ -70,9 +68,9 @@ def test_monopolar_to_bipolar_filter_norhino():
     ts2 = timeseries.TimeSeries.create(
         data, rate, coords=coords2,
         dims=dims2, name="test", attrs={'test_attr': 1})
-    m2b3 = MonopolarToBipolarMapper(timeseries=ts2, channels_dim='electrodes',
+    m2b3 = MonopolarToBipolarMapper(channels_dim='electrodes',
                                     bipolar_pairs=bipolar_pairs1)
-    ts_m2b3 = m2b3.filter()
+    ts_m2b3 = m2b3.filter(ts2)
     assert np.all(ts_m2b3.values == ts_m2b1.values)
     # checking each coord is probably redundant (mismatching coords
     # should cause failure in the above assertion), but won't hurt
@@ -91,21 +89,25 @@ def test_monopolar_to_bipolar_filter_norhino():
     assert np.all(ts_m2b3['electrodes'] == bipolar_pairs2)
     assert np.all(ts_m2b3 == (ts.sel(channels=range(9)).values -
                               ts.sel(channels=range(1,10)).values))
-    m2b4 = MonopolarToBipolarMapper(timeseries=ts2, channels_dim='electrodes',
+    m2b4 = MonopolarToBipolarMapper(channels_dim='electrodes',
                                     bipolar_pairs=bipolar_pairs2)
-    ts_m2b4 = m2b4.filter()
+    ts_m2b4 = m2b4.filter(ts2)
     assert np.all(ts_m2b4 == ts_m2b3)
+
     # checking each coord is probably redundant (mismatching coords
     # should cause failure in the above assertion), but won't hurt
     for coord in ts_m2b4.coords:
         assert np.all(ts_m2b3[coord] == ts_m2b4[coord])
+
     # sanity check that we haven't lost any coords:
     for coord in ts.coords:
         if coord != 'channels':
             assert np.all(ts[coord] == ts_m2b4[coord])
+
     for attr in ts.attrs:
         assert np.all(ts_m2b4.attrs[attr] == ts_m2b1.attrs[attr])
         assert np.all(ts.attrs[attr] == ts_m2b4.attrs[attr])
+
     assert ts.name == ts_m2b4.name
     assert np.all(ts_m2b4['electrodes'] == bipolar_pairs2)
     assert np.all(ts_m2b4 == (ts.sel(channels=range(9)).values -
@@ -113,11 +115,12 @@ def test_monopolar_to_bipolar_filter_norhino():
 
     bipolar_pairs3 = np.array([(i, j) for i, j in zip(range(9), range(1,10))],
                               dtype=[('channel0', '<i8'), ('channel1', '<i8')])
-    m2b5 = MonopolarToBipolarMapper(timeseries=ts2, channels_dim='electrodes',
+    m2b5 = MonopolarToBipolarMapper(channels_dim='electrodes',
                                     bipolar_pairs=bipolar_pairs1,
                                     chan_names=['channel0', 'channel1'])
-    ts_m2b5 = m2b5.filter()
+    ts_m2b5 = m2b5.filter(ts2)
     assert np.all(ts_m2b5.values == ts_m2b1.values)
+
     # checking each coord is probably redundant (mismatching coords
     # should cause failure in the above assertion), but won't hurt
     for coord in ts_m2b5.coords:
@@ -126,33 +129,40 @@ def test_monopolar_to_bipolar_filter_norhino():
     for a, b in zip(ts_m2b5['electrodes'], ts_m2b1['channels']):
         assert np.all(
             np.array(a.values.tolist()) == np.array(b.values.tolist()))
+
     # sanity check that we haven't lost any coords:
     for coord in ts.coords:
         if coord != 'channels':
             assert np.all(ts[coord] == ts_m2b5[coord])
+
     for attr in ts.attrs:
         assert np.all(ts_m2b5.attrs[attr] == ts_m2b1.attrs[attr])
         assert np.all(ts.attrs[attr] == ts_m2b5.attrs[attr])
+
     assert ts.name == ts_m2b5.name
     assert np.all(ts_m2b5['electrodes'] == bipolar_pairs3)
     assert np.all(ts_m2b5 == (ts.sel(channels=range(9)).values -
                               ts.sel(channels=range(1,10)).values))
-    m2b6 = MonopolarToBipolarMapper(timeseries=ts2, channels_dim='electrodes',
+    m2b6 = MonopolarToBipolarMapper(channels_dim='electrodes',
                                     chan_names=['channel0', 'channel1'],
                                     bipolar_pairs=bipolar_pairs3)
-    ts_m2b6 = m2b6.filter()
+    ts_m2b6 = m2b6.filter(ts2)
     assert np.all(ts_m2b6 == ts_m2b5)
+
     # checking each coord is probably redundant (mismatching coords
     # should cause failure in the above assertion), but won't hurt
     for coord in ts_m2b6.coords:
         assert np.all(ts_m2b6[coord] == ts_m2b5[coord])
+
     # sanity check that we haven't lost any coords:
     for coord in ts.coords:
         if coord != 'channels':
             assert np.all(ts[coord] == ts_m2b6[coord])
+
     for attr in ts.attrs:
         assert np.all(ts_m2b6.attrs[attr] == ts_m2b1.attrs[attr])
         assert np.all(ts.attrs[attr] == ts_m2b6.attrs[attr])
+
     assert ts.name == ts_m2b6.name
     assert np.all(ts_m2b6['electrodes'] == bipolar_pairs3)
     assert np.all(ts_m2b6 == (ts.sel(channels=range(9)).values -
@@ -203,19 +213,19 @@ class TestFilters(unittest.TestCase):
         session_reader = EEGReader(session_dataroot=dataroot, channels=self.monopolar_channels)
         session_eegs = session_reader.read()
 
-        sedc = DataChopper(events=self.base_events, timeseries=session_eegs,
+        sedc = DataChopper(events=self.base_events,
                            start_time=self.start_time, end_time=self.end_time, buffer_time=self.buffer_time)
-        chopped_session = sedc.filter()
+        chopped_session = sedc.filter(session_eegs)
         assert_array_equal(chopped_session, self.base_eegs)
 
-        sedc = DataChopper(start_offsets=self.base_events.eegoffset, timeseries=session_eegs,
+        sedc = DataChopper(start_offsets=self.base_events.eegoffset,
                            start_time=self.start_time, end_time=self.end_time, buffer_time=self.buffer_time)
-        chopped_session = sedc.filter()
+        chopped_session = sedc.filter(session_eegs)
         assert_array_equal(chopped_session, self.base_eegs)
 
     def test_monopolar_to_bipolar_filter(self):
-        m2b = MonopolarToBipolarMapper(timeseries=self.base_eegs, bipolar_pairs=self.bipolar_pairs)
-        bp_base_eegs = m2b.filter()
+        m2b = MonopolarToBipolarMapper(bipolar_pairs=self.bipolar_pairs)
+        bp_base_eegs = m2b.filter(self.base_eegs)
 
         bipolar_pairs = bp_base_eegs['channels'].data
         for i, bp in enumerate(bipolar_pairs):
@@ -231,16 +241,16 @@ class TestFilters(unittest.TestCase):
         session_reader = EEGReader(session_dataroot=dataroot, channels=self.monopolar_channels)
         session_eegs = session_reader.read()
 
-        m2b = MonopolarToBipolarMapper(timeseries=session_eegs, bipolar_pairs=self.bipolar_pairs)
-        bp_session_eegs = m2b.filter()
+        m2b = MonopolarToBipolarMapper(bipolar_pairs=self.bipolar_pairs)
+        bp_session_eegs = m2b.filter(session_eegs)
 
-        sedc = DataChopper(events=self.base_events, timeseries=bp_session_eegs, start_time=self.start_time,
+        sedc = DataChopper(events=self.base_events, start_time=self.start_time,
                            end_time=self.end_time, buffer_time=self.buffer_time)
 
-        bp_session_eegs_chopped = sedc.filter()
+        bp_session_eegs_chopped = sedc.filter(bp_session_eegs)
 
-        m2b = MonopolarToBipolarMapper(timeseries=self.base_eegs, bipolar_pairs=self.bipolar_pairs)
-        bp_base_eegs = m2b.filter()
+        m2b = MonopolarToBipolarMapper(bipolar_pairs=self.bipolar_pairs)
+        bp_base_eegs = m2b.filter(self.base_eegs)
 
         assert_array_equal(bp_session_eegs_chopped, bp_base_eegs)
 
@@ -248,13 +258,12 @@ class TestFilters(unittest.TestCase):
     @pytest.mark.xfail
     def test_wavelets_with_event_data_chopper(self):
         wf_session = MorletWaveletFilter(
-            timeseries=self.session_eegs[:, :, :int(self.session_eegs.shape[2] / 4)],
             freqs=np.logspace(np.log10(3), np.log10(180), 8),
             output='power',
             verbose=True
         )
 
-        pow_wavelet_session = wf_session.filter()
+        pow_wavelet_session = wf_session.filter(self.session_eegs[:, :, :int(self.session_eegs.shape[2] / 4)])
 
         sedc = DataChopper(events=self.base_events, timeseries=pow_wavelet_session, start_time=self.start_time,
                            end_time=self.end_time, buffer_time=self.buffer_time)
@@ -263,13 +272,13 @@ class TestFilters(unittest.TestCase):
         # removing buffer
         chopped_session_pow_wavelet = chopped_session_pow_wavelet[:, :, :, 500:-500]
 
-        wf = MorletWaveletFilter(timeseries=self.base_eegs,
-                                 freqs=np.logspace(np.log10(3), np.log10(180), 8),
-                                 output='power',
-                                 verbose=True
-                                 )
+        wf = MorletWaveletFilter(
+            freqs=np.logspace(np.log10(3), np.log10(180), 8),
+            output='power',
+            verbose=True
+        )
 
-        pow_wavelet = wf.filter()
+        pow_wavelet = wf.filter(self.base_eegs)
 
         pow_wavelet = pow_wavelet[:, :, :, 500:-500]
 
@@ -283,8 +292,8 @@ class TestFilters(unittest.TestCase):
 
         from xarray.testing import assert_equal
 
-        b_filter = ButterworthFilter(timeseries=self.base_eegs, freq_range=[58., 62.], filt_type='stop', order=4)
-        base_eegs_filtered_1 = b_filter.filter()
+        b_filter = ButterworthFilter(freq_range=[58., 62.], filt_type='stop', order=4)
+        base_eegs_filtered_1 = b_filter.filter(self.base_eegs)
 
         base_eegs_filtered_2 = self.base_eegs.filtered(freq_range=[58., 62.], filt_type='stop', order=4)
 
@@ -298,11 +307,14 @@ class TestFilters(unittest.TestCase):
 def time_series():
     times = np.linspace(0, 1, 1000)
     ts = np.sin(8*times) + np.sin(16*times) + np.sin(32*times)
-    return timeseries.TimeSeries(data=ts, dims=('time'),
-                                            coords={
-                                                'time': times,
-                                                'samplerate': 1000
-                                            })
+    return timeseries.TimeSeries(
+        data=ts,
+        dims=('time'),
+        coords={
+            'time': times,
+            'samplerate': 1000
+        }
+    )
 
 
 @pytest.mark.filters
@@ -311,18 +323,19 @@ class TestFiltersExecute:
     def setup_class(cls):
         times = np.linspace(0, 1, 1000)
         ts = np.sin(8*times) + np.sin(16*times) + np.sin(32*times)
-        cls.timeseries = timeseries.TimeSeries(data=ts, dims=('time'),
-                                                coords={
-                                                    'time': times,
-                                                    'samplerate': 1000
-                                                })
+        cls.timeseries = timeseries.TimeSeries(
+            data=ts, dims=('time'),
+            coords={
+                'time': times,
+                'samplerate': 1000
+            }
+        )
 
-    def test_butterworth(self,time_series):
-        bfilter = ButterworthFilter(timeseries=time_series,
-                                    freq_range=[10., 20.],
+    def test_butterworth(self, time_series):
+        bfilter = ButterworthFilter(freq_range=[10., 20.],
                                     filt_type='stop',
                                     order=2)
-        bfilter.filter()
+        bfilter.filter(time_series)
 
     @pytest.mark.morlet
     @pytest.mark.parametrize('output_type', [
@@ -331,10 +344,9 @@ class TestFiltersExecute:
         ['power', 'phase'],
     ])
     def test_morlet(self, output_type):
-        mwf = MorletWaveletFilter(timeseries=self.timeseries,
-                                  freqs=np.array([10., 20., 40.]),
+        mwf = MorletWaveletFilter(freqs=np.array([10., 20., 40.]),
                                   width=4, output=output_type)
-        result = mwf.filter()
+        result = mwf.filter(self.timeseries)
 
         if len(mwf.output) == 1:
             if 'power' in mwf.output:
@@ -342,11 +354,11 @@ class TestFiltersExecute:
             if 'phase' in mwf.output:
                 assert result.data.shape == (3, 1000)
         else:
-            assert result.data.shape == (2,3,1000)
+            assert result.data.shape == (2, 3, 1000)
 
-    def test_resample(self,time_series):
-        rf = ResampleFilter(timeseries=time_series, resamplerate=50.)
-        new_ts = rf.filter()
+    def test_resample(self, time_series):
+        rf = ResampleFilter(resamplerate=50.)
+        new_ts = rf.filter(timeseries=time_series)
         assert len(new_ts) == 50
         assert new_ts.samplerate == 50.
 
@@ -355,9 +367,9 @@ class TestFilterShapes:
     """Filter behavior should not depend on shape of input array."""
     @classmethod
     def setup_class(self):
-        self.times = times = np.linspace(0,1,1000)
+        self.times = times = np.linspace(0, 1, 1000)
         self.data = np.sin(8*times) + np.sin(16*times) + np.sin(32*times)
-        self.freqs = np.array([10,20],dtype=float)
+        self.freqs = np.array([10, 20], dtype=float)
         self.timeseries = timeseries.TimeSeries(data=self.data[None,:],
                                                 coords={
                                                     'offsets': [0],
@@ -367,13 +379,13 @@ class TestFilterShapes:
                                                 dims=('offsets', 'time'))
 
     def test_morlet(self):
-        results0 = MorletWaveletFilter(self.timeseries, freqs=self.freqs,
-                                       width=4, output=['power','phase']).filter()
+        results0 = MorletWaveletFilter(
+            freqs=self.freqs, width=4, output=['power', 'phase']
+        ).filter(self.timeseries)
 
-        results1 = MorletWaveletFilter(self.timeseries.transpose(),
-                                       freqs=self.freqs,
-                                       width=4, output=['power','phase']).filter()
-        print(results0)
+        results1 = MorletWaveletFilter(
+            freqs=self.freqs, width=4, output=['power', 'phase']
+        ).filter(self.timeseries.transpose())
 
         xr.testing.assert_allclose(results0.sel(output='power'),
                                    results1.sel(output='power'))
@@ -382,8 +394,8 @@ class TestFilterShapes:
 
     @pytest.mark.slow
     def test_butterworth(self):
-        filtered0 = ButterworthFilter(self.timeseries, self.freqs).filter()
-        filtered1 = ButterworthFilter(self.timeseries.transpose(), self.freqs).filter()
+        filtered0 = ButterworthFilter(self.freqs).filter(self.timeseries)
+        filtered1 = ButterworthFilter(self.freqs).filter(self.timeseries.transpose())
 
         xr.testing.assert_allclose(filtered0, filtered1.transpose(*filtered0.dims))
 
@@ -400,31 +412,10 @@ class TestBaseFilter:
             }
         )
 
-    @pytest.mark.parametrize("dtype,expected_dtype", [
-        (None, np.float64),
-        (np.float64, np.float64),
-        ("double", np.float64),
-        ("float32", np.float32),
-        ("int", np.int),
-    ])
-    def test_dtypes(self, dtype, expected_dtype):
-        filt = BaseFilter(self.dummy_ts, dtype)
-        assert filt.timeseries.data.dtype == expected_dtype
-
-    @pytest.mark.parametrize("dtype", [np.int8, np.uint16, np.float32])
-    def test_unchanged_dtype(self, dtype):
-        """Special case test where we use a weird input dtype. The previous
-        test works with None since by default Numpy uses float64.
-
-        """
-        ts = self.dummy_ts.astype(dtype)
-        filt = BaseFilter(ts, None)
-        assert filt.timeseries.data.dtype == dtype
-
     def test_filter(self):
         with pytest.raises(NotImplementedError):
-            filt = BaseFilter(self.dummy_ts)
-            filt.filter()
+            filt = BaseFilter()
+            filt.filter(self.dummy_ts)
 
 
 class TestMorletFilter:
@@ -446,5 +437,5 @@ class TestMorletFilter:
             }
         )
 
-        mwf = MorletWaveletFilter(ts, np.array(range(70, 171, 10)), output="power")
-        mwf.filter()
+        mwf = MorletWaveletFilter(np.array(range(70, 171, 10)), output="power")
+        mwf.filter(ts)

--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,3 +1,4 @@
+from copy import copy
 from tempfile import mkdtemp
 import os.path as osp
 import shutil
@@ -47,6 +48,28 @@ def test_arithmetic_operations():
     ts_out = ts_1 + ts_2
 
     print('ts_out=', ts_out)
+
+
+@pytest.mark.parametrize("dtype", [np.int, None, np.float32, np.float64])
+def test_coerce_to(dtype):
+    shape = (1, 10, 100)
+
+    ts = TimeSeries.create(
+        np.random.random(shape),
+        samplerate=1,
+        dims=("a", "b", "c"),
+        coords={
+            "a": np.linspace(0, 1, shape[0]),
+            "b": np.linspace(0, 1, shape[1]),
+            "c": np.linspace(0, 1, shape[2])
+        }
+    )
+
+    orig_dtype = copy(ts.data.dtype)
+    ts.coerce_to(dtype)
+    assert ts.data.dtype == dtype
+    if orig_dtype != dtype:
+        assert ts.data.dtype != orig_dtype
 
 
 def test_hdf(tempdir):


### PR DESCRIPTION
This updates the filtering interface to make `timeseries` a parameter for `BaseFilter.filter` rather than having it be a member variable. This allows for reusing filters on multiple time series as well as adding filter pipeline capabilities.

Closes #215.